### PR TITLE
feat: drop support for Laminas 2, remove last createService methods

### DIFF
--- a/src/Router/RouterFactory.php
+++ b/src/Router/RouterFactory.php
@@ -1,14 +1,9 @@
 <?php
 
-/**
- * Custom Router Factory for api routing
- */
-
 namespace Dvsa\Olcs\Transfer\Router;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Custom Router Factory for api routing
@@ -37,17 +32,5 @@ class RouterFactory implements FactoryInterface
         // Obtain an instance
         $factory = sprintf('%s::factory', $routerClass);
         return call_user_func($factory, $routerConfig);
-    }
-
-    /**
-     * @param ServiceLocatorInterface $serviceLocator
-     * @param $cName
-     * @param $rName
-     * @return mixed
-     * @deprecated Not needed after Laminas 3
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator, $cName = null, $rName = null)
-    {
-        return $this($serviceLocator, null);
     }
 }

--- a/src/Util/Annotation/AnnotationBuilderFactory.php
+++ b/src/Util/Annotation/AnnotationBuilderFactory.php
@@ -3,8 +3,7 @@
 namespace Dvsa\Olcs\Transfer\Util\Annotation;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Class AnnotationBuilderFactory - injects validator manager and filter manager to allow transfer objects to use
@@ -20,17 +19,5 @@ class AnnotationBuilderFactory implements FactoryInterface
         $service->setValidatorManager($container->get('ValidatorManager'));
 
         return $service;
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return mixed
-     * @deprecated Not needed for Laminas 3
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator): AnnotationBuilder
-    {
-        return $this($serviceLocator, AnnotationBuilder::class);
     }
 }

--- a/src/Validators/XmlFactory.php
+++ b/src/Validators/XmlFactory.php
@@ -3,37 +3,16 @@
 namespace Dvsa\Olcs\Transfer\Validators;
 
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\Xml\Security as XmlSecurityValidator;
 
-/**
- * Class XmlFactory
- * @package Dvsa\Olcs\Transfer\Validators
- */
 class XmlFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Xml
     {
-        if (method_exists($container, 'getServiceLocator') && $container->getServiceLocator()) {
-            $container = $container->getServiceLocator();
-        }
-
         $service = new Xml();
         $service->setSecurityValidator($container->get(XmlSecurityValidator::class));
 
         return $service;
-    }
-
-    /**
-     * Create service
-     *
-     * @param ServiceLocatorInterface $serviceLocator
-     * @return mixed
-     * @deprecated Not needed in Laminas 3
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator): Xml
-    {
-        return $this($serviceLocator, Xml::class);
     }
 }


### PR DESCRIPTION
Removes the last createService methods and bumps the FactoryInterface

Related issue: [VOL-3692](https://dvsa.atlassian.net/browse/VOL-3692)
