### PR TITLE
feat: Messaging user level disable/enable commands

### DIFF
--- a/config/backend-routes/messaging/messaging.php
+++ b/config/backend-routes/messaging/messaging.php
@@ -37,6 +37,18 @@ return [
                             'POST' => CommandConfig::getPostConfig(Command\Messaging\Conversation\Close::class)
                         ],
                     ),
+                    'disable' => RouteConfig::getRouteConfig(
+                        'disable',
+                        [
+                            'POST' => CommandConfig::getPostConfig(Command\Messaging\Conversation\Disable::class)
+                        ],
+                    ),
+                    'enable' => RouteConfig::getRouteConfig(
+                        'enable',
+                        [
+                            'POST' => CommandConfig::getPostConfig(Command\Messaging\Conversation\Enable::class)
+                        ],
+                    ),
                 ],
             ),
             'messages' => RouteConfig::getRouteConfig(

--- a/src/Command/Messaging/Conversation/Disable.php
+++ b/src/Command/Messaging/Conversation/Disable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Transfer\Command\Messaging\Conversation;
+
+use Dvsa\Olcs\Transfer\FieldType\Traits\Organisation;
+use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
+use Dvsa\Olcs\Transfer\Command\AbstractCommand;
+
+/**
+ * @Transfer\RouteName("backend/messaging/conversations/disable")
+ * @Transfer\Method("POST")
+ */
+final class Disable extends AbstractCommand
+{
+    use Organisation;
+}

--- a/src/Command/Messaging/Conversation/Enable.php
+++ b/src/Command/Messaging/Conversation/Enable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Transfer\Command\Messaging\Conversation;
+
+use Dvsa\Olcs\Transfer\FieldType\Traits\Organisation;
+use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
+use Dvsa\Olcs\Transfer\Command\AbstractCommand;
+
+/**
+ * @Transfer\RouteName("backend/messaging/conversations/enable")
+ * @Transfer\Method("POST")
+ */
+final class Enable extends AbstractCommand
+{
+    use Organisation;
+}


### PR DESCRIPTION
## Description

Caseworkers can disable messaging functionality for a VOL user. This would be used in instances where the user was abusing the system or breaching terms of service.

Related issue: [VOL-4388](https://dvsa.atlassian.net/browse/VOL-4388)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
