### PR TITLE
feat: Task messaging filter (home page)

### DIFF
--- a/src/Query/Task/TaskList.php
+++ b/src/Query/Task/TaskList.php
@@ -85,6 +85,12 @@ class TaskList extends AbstractQuery implements PagedQueryInterface, OrderedQuer
     protected $showTasks = null;
 
     /**
+     * @Transfer\Filter(\Laminas\Filter\Boolean::class)
+     * @Transfer\Optional
+     */
+    protected bool $messaging = false;
+
+    /**
      * @Transfer\Filter("Laminas\Filter\Boolean")
      * @Transfer\Optional
      */
@@ -168,5 +174,10 @@ class TaskList extends AbstractQuery implements PagedQueryInterface, OrderedQuer
     public function getUrgent()
     {
         return $this->urgent;
+    }
+
+    public function getMessaging(): bool
+    {
+        return $this->messaging;
     }
 }

--- a/test/Query/Task/TaskListTest.php
+++ b/test/Query/Task/TaskListTest.php
@@ -20,6 +20,7 @@ class TaskListTest extends MockeryTestCase
             'date' => 'unit_date',
             'status' => 'unit_status',
             'urgent' => 'unit_urgent',
+            'messaging' => 'unit_messaging',
             'showTasks' => 'unit_showTasks',
             'assignedToTeam' => 'unit_assignedToTeam',
             'transportManager' => 'unit_transportManager',
@@ -43,6 +44,7 @@ class TaskListTest extends MockeryTestCase
         static::assertEquals('unit_date', $sut->getDate());
         static::assertEquals('unit_status', $sut->getStatus());
         static::assertEquals('unit_urgent', $sut->getUrgent());
+        static::assertEquals('unit_messaging', $sut->getMessaging());
         static::assertEquals('unit_showTasks', $sut->getShowTasks());
         static::assertEquals('unit_transportManager', $sut->getTransportManager());
         static::assertEquals('unit_organisation', $sut->getOrganisation());


### PR DESCRIPTION
## Description

Messaging creates a messaging flag task. Tasks are filterable by the messaging flag.

Related issue: [VOL-4381](https://dvsa.atlassian.net/browse/VOL-4381)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
