### PR TITLE
fix: Add missing messaging flag for backend.

### DIFF
--- a/src/Command/Task/CreateTask.php
+++ b/src/Command/Task/CreateTask.php
@@ -47,6 +47,12 @@ final class CreateTask extends AbstractCommand
     protected $urgent;
 
     /**
+     * @Transfer\Filter("Laminas\Filter\StringTrim")
+     * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"Y", "N"}})
+     */
+    protected $messaging;
+
+    /**
      * @Transfer\Filter("Laminas\Filter\Digits")
      * @Transfer\Validator("Laminas\Validator\Digits")
      * @Transfer\Validator("Laminas\Validator\GreaterThan", options={"min": 0})
@@ -116,6 +122,14 @@ final class CreateTask extends AbstractCommand
     public function getUrgent()
     {
         return $this->urgent;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMessaging()
+    {
+        return $this->messaging;
     }
 
     /**


### PR DESCRIPTION
## Description

Last TM letter batch job erroring due to CreateTask::getMessaging() method

Related issue: [VOL-4975](https://dvsa.atlassian.net/browse/VOL-4975)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
