### PR TITLE
fix: Cannot create task, messaging flag is not optional

### DIFF
--- a/src/Command/Task/CreateTask.php
+++ b/src/Command/Task/CreateTask.php
@@ -47,6 +47,7 @@ final class CreateTask extends AbstractCommand
     protected $urgent;
 
     /**
+     * @Transfer\Optional
      * @Transfer\Filter("Laminas\Filter\StringTrim")
      * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"Y", "N"}})
      */


### PR DESCRIPTION
## Description

Cannot create task due to messaging flag being required.

Related issue: [VOL-5050](https://dvsa.atlassian.net/browse/VOL-5050)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
