### PR TITLE
feat: Message footer showing operator first read

### DIFF
--- a/src/FieldType/Traits/Messaging/ReadRolesOptional.php
+++ b/src/FieldType/Traits/Messaging/ReadRolesOptional.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Transfer\FieldType\Traits\Messaging;
+
+/**
+ * Trait Conversation
+ *
+ * @package Dvsa\Olcs\Transfer\FieldType\Traits
+ */
+trait ReadRolesOptional
+{
+    /**
+     * @var bool
+     * @Transfer\Optional
+     * @Transfer\Filter("Laminas\Filter\Boolean")
+     */
+    protected $includeReadRoles = false;
+
+    /**
+     * @Transfer\Optional
+     * @Transfer\ArrayInput
+     * @Transfer\ArrayFilter("Dvsa\Olcs\Transfer\Filter\UniqueItems")
+     * @Transfer\Filter("Laminas\Filter\StringTrim")
+     */
+    protected array $readRoles = [];
+
+
+    public function getIncludeReadRoles(): bool
+    {
+        return $this->includeReadRoles;
+    }
+
+    public function getReadRoles(): array
+    {
+        return $this->readRoles;
+    }
+}

--- a/src/Query/Messaging/Messages/ByConversation.php
+++ b/src/Query/Messaging/Messages/ByConversation.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Dvsa\Olcs\Transfer\Query\Messaging\Messages;
 
 use Dvsa\Olcs\Transfer\FieldType\Traits\Messaging\Conversation;
+use Dvsa\Olcs\Transfer\FieldType\Traits\Messaging\ReadRolesOptional;
 use Dvsa\Olcs\Transfer\Query\PagedQueryInterface;
 use Dvsa\Olcs\Transfer\Query\PagedTrait;
 use Dvsa\Olcs\Transfer\Query\AbstractQuery;
@@ -15,4 +18,5 @@ final class ByConversation extends AbstractQuery implements PagedQueryInterface
 {
     use PagedTrait;
     use Conversation;
+    use ReadRolesOptional;
 }


### PR DESCRIPTION
## Description

Add a footer to internal to show the first operator to read the message.

Related issue: [VOL-5082](https://dvsa.atlassian.net/browse/VOL-5082)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
