### PR TITLE
fix: removed type on BusRegBrowseContextList query

### DIFF
--- a/src/Query/Bus/BusRegBrowseContextList.php
+++ b/src/Query/Bus/BusRegBrowseContextList.php
@@ -25,7 +25,7 @@ class BusRegBrowseContextList extends AbstractQuery implements OrderedQueryInter
      *      }
      * )
      */
-    protected string $context;
+    protected $context;
 
     /**
      * Get context


### PR DESCRIPTION
## Description

Removedr type on $context on BusRegBrowseContextList query

Related issue: None

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
