### PR TITLE
chore!: dropped support for legacy transxchange map processor

### DIFF
--- a/src/Command/Bus/Ebsr/RequestMap.php
+++ b/src/Command/Bus/Ebsr/RequestMap.php
@@ -23,24 +23,10 @@ class RequestMap extends AbstractCommand
     protected $scale;
 
     /**
-     * @Transfer\Filter("Laminas\Filter\Boolean")
-     * @Transfer\Optional
-     */
-    protected $fromNewEbsr;
-
-    /**
      * @return string
      */
     public function getScale()
     {
         return $this->scale;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getFromNewEbsr()
-    {
-        return $this->fromNewEbsr;
     }
 }


### PR DESCRIPTION
## Description

This has been raised in preparation for when the new map processor is released. Once we're happy everything is working in production, this PR can be merged.

Related issue: [VOL-5649](https://dvsa.atlassian.net/browse/VOL-5649)
