### PR TITLE
fix: changing haystack value from `operator-tc` to `tc`

### DIFF
--- a/src/Command/User/CreateUserSelfserve.php
+++ b/src/Command/User/CreateUserSelfserve.php
@@ -31,7 +31,7 @@ final class CreateUserSelfserve extends AbstractCommand
 
     /**
      * @Transfer\Filter("Laminas\Filter\StringTrim")
-     * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"admin", "user", "operator-tc"}})
+     * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"admin", "user", "tc"}})
      */
     protected $permission;
 

--- a/src/Command/User/UpdateUserSelfserve.php
+++ b/src/Command/User/UpdateUserSelfserve.php
@@ -39,7 +39,7 @@ final class UpdateUserSelfserve extends AbstractCommand
 
     /**
      * @Transfer\Filter("Laminas\Filter\StringTrim")
-     * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"admin", "user", "tm", "operator-tc"}})
+     * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"admin", "user", "tm", "tc"}})
      */
     protected $permission;
 


### PR DESCRIPTION
## Description
Changing haystack value from `operator-tc` to `tc`.

Fixing: https://github.com/dvsa/olcs-transfer/pull/91

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
