### PR TITLE
fix: new property to allow licence unlinking for some document deletes

### DIFF
--- a/src/Command/Document/DeleteDocument.php
+++ b/src/Command/Document/DeleteDocument.php
@@ -19,4 +19,18 @@ use Dvsa\Olcs\Transfer\FieldType\Traits\Identity;
 final class DeleteDocument extends AbstractCommand
 {
     use Identity;
+
+    /**
+     * @Transfer\Filter("Laminas\Filter\Boolean")
+     * @Transfer\Optional
+     */
+    protected $unlinkLicence = false;
+
+    /**
+     * @return mixed
+     */
+    public function getUnlinkLicence()
+    {
+        return $this->unlinkLicence;
+    }
 }


### PR DESCRIPTION
## Description

Flag to unlink document from licence before deleting

Related issue: [https://dvsa.atlassian.net/browse/VOL-5967](https://dvsa.atlassian.net/browse/VOL-5967)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
