### PR TITLE
feat: remove caching of section steps on LVA journey, add query to retrieve documents

### DIFF
--- a/config/backend-routes.config.php
+++ b/config/backend-routes.config.php
@@ -721,6 +721,12 @@ $routes = [
                                     'PUT' => CommandConfig::getPutConfig(Command\Application\UploadEvidence::class),
                                 ]
                             ),
+                            'documents' => RouteConfig::getRouteConfig(
+                                'documents',
+                                [
+                                    'GET' => QueryConfig::getConfig(Query\Application\Documents::class),
+                                ]
+                            ),
                         ]
                     ),
                     'POST' => CommandConfig::getPostConfig(Command\Application\CreateApplication::class),

--- a/src/Query/Application/Application.php
+++ b/src/Query/Application/Application.php
@@ -16,7 +16,7 @@ use Dvsa\Olcs\Transfer\Query\AbstractQuery;
 /**
  * @Transfer\RouteName("backend/application/single")
  */
-class Application extends AbstractQuery implements CacheableShortTermQueryInterface
+class Application extends AbstractQuery
 {
     use Identity;
 

--- a/src/Query/Application/Completion.php
+++ b/src/Query/Application/Completion.php
@@ -1,22 +1,15 @@
 <?php
 
-/**
- * Application
- *
- * @author Rob Caiger <rob@clocal.co.uk>
- */
-
 namespace Dvsa\Olcs\Transfer\Query\Application;
 
 use Dvsa\Olcs\Transfer\FieldType\Traits\Identity;
-use Dvsa\Olcs\Transfer\Query\CacheableShortTermQueryInterface;
 use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
 use Dvsa\Olcs\Transfer\Query\AbstractQuery;
 
 /**
  * @Transfer\RouteName("backend/application/single/completion")
  */
-class Completion extends AbstractQuery implements CacheableShortTermQueryInterface
+class Completion extends AbstractQuery
 {
     use Identity;
 }

--- a/src/Query/Application/Documents.php
+++ b/src/Query/Application/Documents.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Transfer\Query\Application;
+
+use Dvsa\Olcs\Transfer\Query\AbstractQuery;
+use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
+use Dvsa\Olcs\Transfer\FieldType\Traits\Category;
+use Dvsa\Olcs\Transfer\FieldType\Traits\Identity;
+use Dvsa\Olcs\Transfer\FieldType\Traits\SubCategory;
+
+/**
+ * @Transfer\RouteName("backend/application/single/documents")
+ */
+class Documents extends AbstractQuery
+{
+    use Identity;
+    use Category;
+    use SubCategory;
+}


### PR DESCRIPTION
## Description

LVA code caches the sections that are available. The PSV restricted journey alters this on the fly based on the input of the user, so these caches can no longer be used. Also includes a query to retreive different types of documents for an application, this is required now we're allowing the upload of different types (categories) of evidence.

Related issue: [VOL-5882](https://dvsa.atlassian.net/browse/VOL-5882)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5882]: https://dvsa.atlassian.net/browse/VOL-5882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ