### PR TITLE
fix: stop escaping the JSON produced by EditorJS to preserve inline f…

### DIFF
--- a/src/FieldType/Traits/EditorJsComment.php
+++ b/src/FieldType/Traits/EditorJsComment.php
@@ -15,6 +15,7 @@ trait EditorJsComment
      * @Transfer\Filter("Laminas\Filter\StringTrim")
      * @Transfer\Validator("Laminas\Validator\IsJsonString")
      * @Transfer\Validator("Laminas\Validator\StringLength",options={"min":5})
+     * @Transfer\Escape(false)
      */
     protected $comment;
 

--- a/src/FieldType/Traits/OptionalEditorJsComment.php
+++ b/src/FieldType/Traits/OptionalEditorJsComment.php
@@ -12,9 +12,11 @@ use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
 trait OptionalEditorJsComment
 {
     /**
+     * @Transfer\Filter("Laminas\Filter\ToNull")
      * @Transfer\Filter("Laminas\Filter\StringTrim")
      * @Transfer\Validator("Laminas\Validator\IsJsonString")
      * @Transfer\Optional
+     * @Transfer\Escape(false)
      */
     protected $comment;
 


### PR DESCRIPTION
…ormatting like bold and italic

## Description

dont escape EditorJS json payloads as it was removing inline text formatting

Related issue: [VOL-6505](https://dvsa.atlassian.net/browse/VOL-6505)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?


[VOL-6505]: https://dvsa.atlassian.net/browse/VOL-6505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ