### PR TITLE
refactor!: CI passing on PHP 8.2 and 8.3, bump dependencies, fix static analysis VOL-6497

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,8 @@ jobs:
   static-analysis:
     uses: dvsa/.github/.github/workflows/php-library-static.yml@main
     with:
-      php-version: '8.2'
+      php-version: '8.3'
+      stability: '["prefer-stable"]'
 
   tests:
     uses: dvsa/.github/.github/workflows/php-library-tests.yml@main

--- a/composer.json
+++ b/composer.json
@@ -2,28 +2,28 @@
     "name": "olcs/olcs-transfer",
     "description": "OLCS Transfer",
     "require": {
-        "php": "^8.2",
+        "php": "~8.2.0 || ~8.3.0",
         "ext-openssl": "*",
-        "laminas/laminas-stdlib": "^3.0",
-        "laminas/laminas-filter": "^2.30",
-        "laminas/laminas-validator": ">=2.30.0",
-        "laminas/laminas-servicemanager": "^3.3",
-        "laminas/laminas-inputfilter": "^2.21",
-        "laminas/laminas-form": "^3.1.1",
+        "laminas/laminas-stdlib": "^3.20",
+        "laminas/laminas-filter": "^2.41",
+        "laminas/laminas-validator": "^2.64",
+        "laminas/laminas-servicemanager": "^3.23",
+        "laminas/laminas-inputfilter": "^2.33",
+        "laminas/laminas-form": "^3.21",
         "laminas/laminas-crypt": "^4",
-        "laminas/laminas-xml": "^1.4.0",
-        "laminas/laminas-cache": "^3.6",
-        "laminas/laminas-cache-storage-adapter-redis": "^2.4",
-        "laminas/laminas-router": "^3.9",
+        "laminas/laminas-xml": "^1.7.0",
+        "laminas/laminas-cache": "^3.13",
+        "laminas/laminas-cache-storage-adapter-redis": "^2.7",
+        "laminas/laminas-router": "^3.14",
         "psr/container": "^1.1|^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "mockery/mockery": "^1.6",
         "johnkary/phpunit-speedtrap": "^4.0",
-        "bamarni/composer-bin-plugin": "^1.8",
+        "bamarni/composer-bin-plugin": "^1.8.2",
         "doctrine/annotations": "^1.14.2",
-        "phpstan/phpstan-mockery": "^1.1"
+        "phpstan/phpstan-mockery": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,19 @@ parameters:
   paths:
     - test
     - src
-  ignoreErrors: []
+  ignoreErrors:
+  - # Laminas have added annotations to say classes we extend will be final in subsequent versions - we can't easily fix this
+      identifier: class.extendsFinalByPhpDoc
+      paths:
+        - 'src/Validators'
+        - 'src/Util/ArrayInput.php'
+  - # Laminas have added annotations to say classes we extend will be final in subsequent versions - we can't easily fix this
+      identifier: property.parentPropertyFinalByPhpDoc
+      paths:
+        - 'src/Validators'
+  - # There are 24 traits which are unused, however, they may be used by commands running on API nodes - see VOL-6570
+      identifier: trait.unused
+      paths:
+        - 'src/FieldType/Traits'
 includes:
   - vendor/phpstan/phpstan-mockery/extension.neon

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -13,4 +13,20 @@
       <directory name="vendor"/>
     </ignoreFiles>
   </projectFiles>
+    <issueHandlers>
+      <InvalidExtendClass>
+        <errorLevel type="suppress">
+          <!-- Laminas have added annotations to some classes we extend, to signify they will be final in upcoming versions -->
+          <directory name="src/Validators" />
+          <file name="src/Util/ArrayInput.php" />
+        </errorLevel>
+      </InvalidExtendClass>
+      <MethodSignatureMismatch>
+        <errorLevel type="suppress">
+          <!-- Laminas have added annotations to some classes we extend, to signify they will be final in upcoming versions -->
+          <directory name="src/Validators" />
+          <file name="src/Util/ArrayInput.php" />
+        </errorLevel>
+      </MethodSignatureMismatch>
+    </issueHandlers>
 </psalm>

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -15,6 +15,7 @@ abstract class AbstractCommand implements CommandInterface
      *
      * @return static
      */
+    #[\Override]
     public static function create(array $data)
     {
         $command = new static();
@@ -29,6 +30,7 @@ abstract class AbstractCommand implements CommandInterface
      *
      * @return void
      */
+    #[\Override]
     public function exchangeArray(array $array)
     {
         $values = get_object_vars($this);
@@ -45,6 +47,7 @@ abstract class AbstractCommand implements CommandInterface
      *
      * @return array
      */
+    #[\Override]
     public function getArrayCopy()
     {
         return get_object_vars($this);

--- a/src/Command/CommandContainer.php
+++ b/src/Command/CommandContainer.php
@@ -34,46 +34,55 @@ class CommandContainer implements CommandContainerInterface
      */
     protected $dto;
 
+    #[\Override]
     public function setInputFilter(InputFilterInterface $inputFilter)
     {
         $this->inputFilter = $inputFilter;
     }
 
+    #[\Override]
     public function getInputFilter()
     {
         return $this->inputFilter;
     }
 
+    #[\Override]
     public function setDto(CommandInterface $dto)
     {
         $this->dto = $dto;
     }
 
+    #[\Override]
     public function getDto()
     {
         return $this->dto;
     }
 
+    #[\Override]
     public function setRouteName($routeName)
     {
         $this->routeName = $routeName;
     }
 
+    #[\Override]
     public function getRouteName()
     {
         return $this->routeName;
     }
 
+    #[\Override]
     public function setMethod($method)
     {
         $this->method = $method;
     }
 
+    #[\Override]
     public function getMethod()
     {
         return $this->method;
     }
 
+    #[\Override]
     public function isValid()
     {
         $this->hasValidated = true;
@@ -85,6 +94,7 @@ class CommandContainer implements CommandContainerInterface
         return $this->inputFilter->isValid();
     }
 
+    #[\Override]
     public function getMessages()
     {
         if ($this->hasValidated === false) {

--- a/src/Command/Partial/ApplicationTracking.php
+++ b/src/Command/Partial/ApplicationTracking.php
@@ -418,16 +418,6 @@ class ApplicationTracking extends AbstractCommand
         return $this->declarationsInternalStatus;
     }
 
-    /**
-     * Gets the value of vehiclesDeclarationsStatus.
-     *
-     * @return mixed
-     */
-    public function getVehiclesDeclarationsStatus()
-    {
-        return $this->vehiclesDeclarationsStatus;
-    }
-
     public function getVehiclesSizeStatus(): ?string
     {
         return $this->vehiclesSizeStatus;

--- a/src/FieldType/Traits/CabotageOptional.php
+++ b/src/FieldType/Traits/CabotageOptional.php
@@ -17,7 +17,7 @@ trait CabotageOptional
     protected $cabotage;
 
     /**
-     * @return int
+     * @return ?int
      */
     public function getCabotage()
     {

--- a/src/FieldType/Traits/IrhpPermitRangeTypeOptional.php
+++ b/src/FieldType/Traits/IrhpPermitRangeTypeOptional.php
@@ -18,7 +18,7 @@ trait IrhpPermitRangeTypeOptional
     protected $irhpPermitRangeType;
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getIrhpPermitRangeType()
     {

--- a/src/FieldType/Traits/IrhpPermitTypeOptional.php
+++ b/src/FieldType/Traits/IrhpPermitTypeOptional.php
@@ -23,7 +23,7 @@ trait IrhpPermitTypeOptional
     protected $irhpPermitType;
 
     /**
-     * @return int
+     * @return ?int
      */
     public function getIrhpPermitType()
     {

--- a/src/FieldType/Traits/JourneyOptional.php
+++ b/src/FieldType/Traits/JourneyOptional.php
@@ -16,7 +16,7 @@ trait JourneyOptional
     protected $journey;
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getJourney()
     {

--- a/src/FieldType/Traits/TranslateToWelshOptional.php
+++ b/src/FieldType/Traits/TranslateToWelshOptional.php
@@ -15,7 +15,7 @@ trait TranslateToWelshOptional
     protected $translateToWelsh;
 
     /**
-     * @return string
+     * @return ?string
      */
     public function getTranslateToWelsh()
     {

--- a/src/FieldType/Traits/ValidOnlyOptional.php
+++ b/src/FieldType/Traits/ValidOnlyOptional.php
@@ -16,7 +16,7 @@ trait ValidOnlyOptional
     protected $validOnly;
 
     /**
-     * @return bool
+     * @return ?bool
      */
     public function getValidOnly()
     {

--- a/src/Filter/FilterEmptyItems.php
+++ b/src/Filter/FilterEmptyItems.php
@@ -19,6 +19,7 @@ class FilterEmptyItems extends AbstractFilter
      * @param mixed $value
      * @return array|mixed
      */
+    #[\Override]
     public function filter($value)
     {
         if (!is_array($value)) {

--- a/src/Filter/Postcode.php
+++ b/src/Filter/Postcode.php
@@ -31,6 +31,7 @@ class Postcode implements FilterInterface
      * @param  mixed $value
      * @return string
      */
+    #[\Override]
     public function filter($value)
     {
         // apply StringTrim filter

--- a/src/Filter/UniqueItems.php
+++ b/src/Filter/UniqueItems.php
@@ -13,6 +13,7 @@ use Laminas\Filter\AbstractFilter;
  */
 class UniqueItems extends AbstractFilter
 {
+    #[\Override]
     public function filter($value)
     {
         return array_unique($value);

--- a/src/Filter/Vrm.php
+++ b/src/Filter/Vrm.php
@@ -42,6 +42,7 @@ class Vrm extends AbstractFilter
      * @param  mixed $value
      * @return string
      */
+    #[\Override]
     public function filter($value)
     {
         // Strip all whitespace

--- a/src/Query/AbstractQuery.php
+++ b/src/Query/AbstractQuery.php
@@ -28,6 +28,7 @@ abstract class AbstractQuery implements QueryInterface
      *
      * @return static
      */
+    #[\Override]
     public static function create(array $data)
     {
         $command = new static();
@@ -42,6 +43,7 @@ abstract class AbstractQuery implements QueryInterface
      *
      * @return void
      */
+    #[\Override]
     public function exchangeArray(array $array)
     {
         $values = get_object_vars($this);
@@ -58,6 +60,7 @@ abstract class AbstractQuery implements QueryInterface
      *
      * @return array
      */
+    #[\Override]
     public function getArrayCopy()
     {
         return get_object_vars($this);

--- a/src/Query/Licence/GoodsVehicles.php
+++ b/src/Query/Licence/GoodsVehicles.php
@@ -38,6 +38,7 @@ class GoodsVehicles extends AbstractGoodsVehicles implements PagedQueryInterface
      *
      * @return array|null
      */
+    #[\Override]
     public function getVehicleIds(): ?array
     {
         return $this->vehicleIds;

--- a/src/Query/Licence/Vehicles.php
+++ b/src/Query/Licence/Vehicles.php
@@ -70,6 +70,7 @@ class Vehicles extends AbstractQuery implements
     /**
      * @return mixed
      */
+    #[\Override]
     public function getIncludeActive()
     {
         return $this->includeActive;

--- a/src/Query/QueryContainer.php
+++ b/src/Query/QueryContainer.php
@@ -26,11 +26,13 @@ class QueryContainer implements QueryContainerInterface
      */
     protected $dto;
 
+    #[\Override]
     public function setInputFilter(InputFilterInterface $inputFilter)
     {
         $this->inputFilter = $inputFilter;
     }
 
+    #[\Override]
     public function getInputFilter()
     {
         return $this->inputFilter;
@@ -41,6 +43,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isCustomCacheable(): bool
     {
         return ($this->dto instanceof CustomCacheableInterface);
@@ -51,6 +54,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isShortTermCacheable()
     {
         return ($this->dto instanceof CacheableShortTermQueryInterface);
@@ -61,6 +65,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isMediumTermCacheable()
     {
         return ($this->dto instanceof CacheableMediumTermQueryInterface);
@@ -71,6 +76,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isLongTermCacheable(): bool
     {
         return ($this->dto instanceof CacheableLongTermQueryInterface);
@@ -81,6 +87,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isPersistentCacheable(): bool
     {
         return $this->isLongTermCacheable() || $this->isMediumTermCacheable();
@@ -91,6 +98,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isPublicCacheable(): bool
     {
         return ($this->dto instanceof PublicQueryCacheInterface);
@@ -101,6 +109,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isSharedEncryptionCacheable(): bool
     {
         return ($this->dto instanceof SharedEncryptionCacheInterface);
@@ -111,6 +120,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isStream()
     {
         return ($this->dto instanceof StreamInterface);
@@ -129,11 +139,13 @@ class QueryContainer implements QueryContainerInterface
         return md5($dtoClassName . '-' . $jsonData);
     }
 
+    #[\Override]
     public function setDto(QueryInterface $dto)
     {
         $this->dto = $dto;
     }
 
+    #[\Override]
     public function getDto()
     {
         return $this->dto;
@@ -144,21 +156,25 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return string
      */
+    #[\Override]
     public function getDtoClassName(): string
     {
         return $this->dto::class;
     }
 
+    #[\Override]
     public function setRouteName($routeName)
     {
         $this->routeName = $routeName;
     }
 
+    #[\Override]
     public function getRouteName()
     {
         return $this->routeName;
     }
 
+    #[\Override]
     public function isValid()
     {
         $this->hasValidated = true;
@@ -169,6 +185,7 @@ class QueryContainer implements QueryContainerInterface
         return $this->inputFilter->isValid();
     }
 
+    #[\Override]
     public function getMessages()
     {
         if ($this->hasValidated === false) {
@@ -183,6 +200,7 @@ class QueryContainer implements QueryContainerInterface
      *
      * @return string
      */
+    #[\Override]
     public function getEncryptionMode(): string
     {
         if ($this->isPublicCacheable()) {

--- a/src/Router/Query.php
+++ b/src/Router/Query.php
@@ -6,6 +6,7 @@ use Laminas\Router\Http\Method;
 
 class Query extends Method
 {
+    #[\Override]
     public function assemble(array $params = [], array $options = [])
     {
         $mergedParams = array_merge($this->defaults, $params);

--- a/src/Router/RouterFactory.php
+++ b/src/Router/RouterFactory.php
@@ -10,6 +10,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
  */
 class RouterFactory implements FactoryInterface
 {
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $config = $container->has('Config') ? $container->get('Config') : [];

--- a/src/Service/CacheEncryptionFactory.php
+++ b/src/Service/CacheEncryptionFactory.php
@@ -21,6 +21,7 @@ class CacheEncryptionFactory implements FactoryInterface
      * @throws \Exception
      * @return CacheEncryption
      */
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): CacheEncryption
     {
         $config = $container->get('Config');

--- a/src/Util/Annotation/AnnotationBuilderFactory.php
+++ b/src/Util/Annotation/AnnotationBuilderFactory.php
@@ -12,6 +12,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
  */
 class AnnotationBuilderFactory implements FactoryInterface
 {
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): AnnotationBuilder
     {
         $service = new AnnotationBuilder();

--- a/src/Util/ArrayInput.php
+++ b/src/Util/ArrayInput.php
@@ -54,6 +54,7 @@ class ArrayInput extends \Laminas\InputFilter\ArrayInput
     /**
      * @return array
      */
+    #[\Override]
     public function getValue()
     {
         $values = parent::getValue();
@@ -69,6 +70,7 @@ class ArrayInput extends \Laminas\InputFilter\ArrayInput
      * @param  mixed $context Extra "context" to provide the validator
      * @return bool
      */
+    #[\Override]
     public function isValid($context = null)
     {
         $values = $this->getValue();
@@ -89,6 +91,7 @@ class ArrayInput extends \Laminas\InputFilter\ArrayInput
      *
      * @return array<string, string>
      */
+    #[\Override]
     public function getMessages()
     {
         $validator = $this->getArrayValidatorChain();

--- a/src/Util/StructuredInput.php
+++ b/src/Util/StructuredInput.php
@@ -13,7 +13,8 @@ use Laminas\InputFilter\EmptyContextInterface;
  * Structured Input (Kind of a mashup between an Input and InputFilter)
  * - Manages validation and filtering on nested inputs whilst also allowing validation and filtering on itself
  *
- * @author Rob Caiger <rob@clocal.co.uk>
+ * @template TFilteredValues
+ * @implements InputFilterInterface<TFilteredValues>
  */
 class StructuredInput implements InputInterface, InputFilterInterface
 {
@@ -100,6 +101,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function setAllowEmpty($allowEmpty)
     {
         $this->allowEmpty = $allowEmpty;
@@ -113,6 +115,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function setBreakOnFailure($breakOnFailure)
     {
         $this->breakOnFailure = $breakOnFailure;
@@ -126,6 +129,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
 
      * @return static
      */
+    #[\Override]
     public function setErrorMessage($errorMessage)
     {
         $this->errorMessage = $errorMessage;
@@ -139,6 +143,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function setFilterChain(FilterChain $filterChain)
     {
         $this->filterChain = $filterChain;
@@ -152,6 +157,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function setName($name)
     {
         $this->name = $name;
@@ -165,6 +171,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function setRequired($required)
     {
         $this->required = $required;
@@ -178,6 +185,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function setValidatorChain(ValidatorChain $validatorChain)
     {
         $this->validatorChain = $validatorChain;
@@ -191,6 +199,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function setValue($value)
     {
         $this->setData($value);
@@ -204,6 +213,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return static
      */
+    #[\Override]
     public function merge(InputInterface $input)
     {
         return $this;
@@ -214,6 +224,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function allowEmpty()
     {
         return $this->allowEmpty;
@@ -224,6 +235,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function breakOnFailure()
     {
         return $this->breakOnFailure;
@@ -234,6 +246,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return string|null
      */
+    #[\Override]
     public function getErrorMessage()
     {
         return $this->errorMessage;
@@ -244,6 +257,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return \Laminas\Filter\FilterChain
      */
+    #[\Override]
     public function getFilterChain()
     {
         return $this->filterChain;
@@ -254,6 +268,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return string|null
      */
+    #[\Override]
     public function getName()
     {
         return $this->name;
@@ -264,6 +279,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isRequired()
     {
         return $this->required;
@@ -274,6 +290,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return ValidatorChain
      */
+    #[\Override]
     public function getValidatorChain(): ValidatorChain
     {
         return $this->validatorChain;
@@ -286,6 +303,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      * @param string|null                                                                                  $name  Name
      * @return self
      */
+    #[\Override]
     public function add($input, $name = null)
     {
         if ($name === null) {
@@ -300,6 +318,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      * Get
      *
      */
+    #[\Override]
     public function get($name)
     {
         return $this->inputs[$name];
@@ -312,6 +331,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function has($name): bool
     {
         return isset($this->inputs[$name]);
@@ -324,6 +344,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return self
      */
+    #[\Override]
     public function remove($name)
     {
         unset($this->inputs[$name]);
@@ -337,6 +358,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return self
      */
+    #[\Override]
     public function setData($data)
     {
         $this->data = $data;
@@ -351,6 +373,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return bool
      */
+    #[\Override]
     public function isValid($context = null): bool
     {
         if (empty($this->data) && !$this->isRequired()) {
@@ -374,6 +397,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return self
      */
+    #[\Override]
     public function setValidationGroup($name)
     {
         return $this;
@@ -384,6 +408,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return array<string, InputInterface|InputFilterInterface>
      */
+    #[\Override]
     public function getInvalidInput()
     {
         return $this->invalidInputs;
@@ -394,6 +419,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return array<string, InputInterface|InputFilterInterface>
      */
+    #[\Override]
     public function getValidInput()
     {
         return $this->validInputs;
@@ -406,6 +432,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return array|null
      */
+    #[\Override]
     public function getValue($name = null): ?array
     {
         if ($name !== null) {
@@ -420,6 +447,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return array<string, mixed>|null
      */
+    #[\Override]
     public function getValues(): ?array
     {
         if (empty($this->data)) {
@@ -446,6 +474,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return mixed
      */
+    #[\Override]
     public function getRawValue($name = null)
     {
         if ($name !== null) {
@@ -460,6 +489,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return array
      */
+    #[\Override]
     public function getRawValues()
     {
         $values = [];
@@ -473,9 +503,9 @@ class StructuredInput implements InputInterface, InputFilterInterface
 
     /**
      * Get messages
-     * @return array<string, array<array<string>|string>> Error messages
-     * @phpstan-ignore-next-line
+     * @return array<array-key, array<array-key, string|array>> | array<array-key, string> Error messages
      */
+    #[\Override]
     public function getMessages()
     {
         if ($this->messages !== null) {
@@ -495,6 +525,7 @@ class StructuredInput implements InputInterface, InputFilterInterface
      *
      * @return int
      */
+    #[\Override]
     public function count(): int
     {
         return count($this->inputs);

--- a/src/Validators/AbstractCompare.php
+++ b/src/Validators/AbstractCompare.php
@@ -110,6 +110,7 @@ abstract class AbstractCompare extends AbstractValidator
      *
      * @param mixed $options
      */
+    #[\Override]
     public function setOptions($options = [])
     {
         if (isset($options['compare_to'])) {
@@ -134,6 +135,7 @@ abstract class AbstractCompare extends AbstractValidator
      * @param  array $context
      * @return bool
      */
+    #[\Override]
     abstract public function isValid($value, array $context = null);
 
     /**

--- a/src/Validators/Date.php
+++ b/src/Validators/Date.php
@@ -29,6 +29,7 @@ class Date extends LaminasDate
      * @param  mixed $value
      * @return bool
      */
+    #[\Override]
     public function isValid($value)
     {
         if (is_null($value)) {

--- a/src/Validators/DateCompare.php
+++ b/src/Validators/DateCompare.php
@@ -56,8 +56,8 @@ class DateCompare extends AbstractCompare
      * Sets options
      *
      * @param  mixed $options
-     * @return static
      */
+    #[\Override]
     public function setOptions($options = []): AbstractValidator
     {
         if (isset($options['has_time'])) {
@@ -75,6 +75,7 @@ class DateCompare extends AbstractCompare
      * @param  array $context
      * @return bool
      */
+    #[\Override]
     public function isValid($value, array $context = null)
     {
         if (empty($value)) {

--- a/src/Validators/DateInFuture.php
+++ b/src/Validators/DateInFuture.php
@@ -113,6 +113,7 @@ class DateInFuture extends AbstractValidator
      *
      * @return AbstractValidator
      */
+    #[\Override]
     public function setOptions($options = []): AbstractValidator
     {
         if (isset($options['include_today'])) {
@@ -145,6 +146,7 @@ class DateInFuture extends AbstractValidator
      * @return bool
      * @throws Exception if the token doesn't exist in the context array
      */
+    #[\Override]
     public function isValid($value)
     {
         if (empty($value) && $this->getAllowEmpty()) {

--- a/src/Validators/DateNotInFuture.php
+++ b/src/Validators/DateNotInFuture.php
@@ -39,6 +39,7 @@ class DateNotInFuture extends AbstractValidator
      * @param  mixed $value
      * @return bool
      */
+    #[\Override]
     public function isValid($value)
     {
         $date = new \DateTime($value);

--- a/src/Validators/EmailAddress.php
+++ b/src/Validators/EmailAddress.php
@@ -109,6 +109,7 @@ class EmailAddress extends AbstractValidator
      * @param  string $messageKey     OPTIONAL
      * @return static Provides a fluent interface
      */
+    #[\Override]
     public function setMessage($messageString, $messageKey = null): AbstractValidator
     {
         if ($messageKey === null) {
@@ -136,7 +137,7 @@ class EmailAddress extends AbstractValidator
     public function getHostnameValidator()
     {
         if (!isset($this->options['hostnameValidator'])) {
-            /** @phpstan-ignore-next-line
+            /**
              * @psalm-suppress InvalidArgument
              *
              * Docblock types as array, but handles non-array values.
@@ -297,6 +298,7 @@ class EmailAddress extends AbstractValidator
      * @param  mixed $value
      * @return bool
      */
+    #[\Override]
     public function isValid($value)
     {
         // Check length

--- a/src/Validators/FhAdditionalInfo.php
+++ b/src/Validators/FhAdditionalInfo.php
@@ -53,6 +53,7 @@ class FhAdditionalInfo extends LaminasValidator\AbstractValidator
      *
      * @return bool
      */
+    #[\Override]
     public function isValid($value, $context = null)
     {
         $this->setValue($value);

--- a/src/Validators/InArrayExtra.php
+++ b/src/Validators/InArrayExtra.php
@@ -15,6 +15,7 @@ abstract class InArrayExtra extends \Laminas\Validator\InArray
      *
      * @return array
      */
+    #[\Override]
     public function getHaystack()
     {
         return array_unique(

--- a/src/Validators/Money.php
+++ b/src/Validators/Money.php
@@ -40,6 +40,7 @@ class Money extends AbstractValidator
      *
      * @return bool
      */
+    #[\Override]
     public function isValid($value)
     {
         // None numerics are not allowed
@@ -76,16 +77,14 @@ class Money extends AbstractValidator
      * Set validator options
      *
      * @param mixed $options Options to set
-     *
-     * @phpstan-ignore-next-line
-     * @return void
      */
-    public function setOptions($options = [])
+    #[\Override]
+    public function setOptions($options = []): AbstractValidator
     {
         if (isset($options['allow_negative']) && $options['allow_negative'] == true) {
             $this->allowNegative = true;
         }
 
-        parent::setOptions($options);
+        return parent::setOptions($options);
     }
 }

--- a/src/Validators/Order.php
+++ b/src/Validators/Order.php
@@ -15,6 +15,7 @@ class Order extends \Laminas\Validator\AbstractValidator
         self::NOT_ASC_OR_DESC => 'The order was not ASC or DESC',
     ];
 
+    #[\Override]
     public function isValid($value)
     {
         if (!is_string($value)) {

--- a/src/Validators/Postcode.php
+++ b/src/Validators/Postcode.php
@@ -63,6 +63,7 @@ class Postcode extends AbstractValidator
      * @param mixed $options
      * @return AbstractValidator
      */
+    #[\Override]
     public function setOptions($options = []): AbstractValidator
     {
         if (isset($options['allow_empty'])) {
@@ -82,6 +83,7 @@ class Postcode extends AbstractValidator
      * @param array $context
      * @return bool
      */
+    #[\Override]
     public function isValid($value, $context = null)
     {
         if (empty($value) && $this->allowEmpty()) {

--- a/src/Validators/Sort.php
+++ b/src/Validators/Sort.php
@@ -10,6 +10,7 @@ class Sort extends \Laminas\Validator\AbstractValidator
         self::INVALID_SORT => 'The sort value is not valid',
     ];
 
+    #[\Override]
     public function isValid($value)
     {
         if (!is_string($value)) {

--- a/src/Validators/TrailerRegNumber.php
+++ b/src/Validators/TrailerRegNumber.php
@@ -19,13 +19,10 @@ class TrailerRegNumber extends Regex
     ];
 
     /**
-     * Sets validator options
+     * Sets validator options (default pattern 1 letter followed by 7 digits)
      */
-    public function __construct()
+    public function __construct(string $pattern = '/^[A-Za-z][0-9]{7}$/')
     {
-        // 1 letter followed by 7 digits
-        $pattern = '/^[A-Za-z][0-9]{7}$/';
-
         parent::__construct($pattern);
     }
 }

--- a/src/Validators/UploadEvidence.php
+++ b/src/Validators/UploadEvidence.php
@@ -25,6 +25,7 @@ class UploadEvidence extends AbstractValidator
      *
      * @return bool
      */
+    #[\Override]
     public function isValid($value, $context = null)
     {
         $isValid = true;

--- a/src/Validators/Username.php
+++ b/src/Validators/Username.php
@@ -38,6 +38,7 @@ class Username extends StringLength
      * @param mixed $value
      * @return bool
      */
+    #[\Override]
     public function isValid($value)
     {
         if (parent::isValid($value)) {

--- a/src/Validators/UsernameCreate.php
+++ b/src/Validators/UsernameCreate.php
@@ -34,6 +34,7 @@ class UsernameCreate extends StringLength
      * @param mixed $value
      * @return bool
      */
+    #[\Override]
     public function isValid($value)
     {
         if (parent::isValid($value)) {

--- a/src/Validators/ValidateEach.php
+++ b/src/Validators/ValidateEach.php
@@ -31,6 +31,7 @@ class ValidateEach extends IsCountable
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function isValid($value)
     {
         if (! parent::isValid($value)) {
@@ -77,6 +78,7 @@ class ValidateEach extends IsCountable
     /**
      * @inheritDoc
      */
+    #[\Override]
     public function getMessages()
     {
         return $this->abstractOptions['messages'];

--- a/src/Validators/Vrm.php
+++ b/src/Validators/Vrm.php
@@ -184,6 +184,7 @@ class Vrm extends AbstractValidator
      *
      * @return bool
      */
+    #[\Override]
     public function isValid($value)
     {
         if (in_array($value, $this->exceptions)) {

--- a/src/Validators/Xml.php
+++ b/src/Validators/Xml.php
@@ -53,6 +53,7 @@ class Xml extends AbstractValidator
      * @param mixed $value
      * @return string|bool
      */
+    #[\Override]
     public function isValid($value)
     {
         try {

--- a/src/Validators/XmlFactory.php
+++ b/src/Validators/XmlFactory.php
@@ -8,6 +8,7 @@ use Laminas\Xml\Security as XmlSecurityValidator;
 
 class XmlFactory implements FactoryInterface
 {
+    #[\Override]
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Xml
     {
         $service = new Xml();

--- a/test/DtoWithoutFieldTransformationsTest.php
+++ b/test/DtoWithoutFieldTransformationsTest.php
@@ -10,12 +10,11 @@ use PHPUnit\Framework\Assert as Assert;
 trait DtoWithoutFieldTransformationsTest
 {
     /**
-     * @inheritDoc
+     * @doesNotPerformAssertions
      */
     public function testFieldTransformations()
     {
         // the test as defined by DtoTest is only relevant to Dto with filtered fields
-        Assert::assertTrue(true);
     }
 
     /**

--- a/test/DtoWithoutInvalidFieldTest.php
+++ b/test/DtoWithoutInvalidFieldTest.php
@@ -10,12 +10,11 @@ use PHPUnit\Framework\Assert as Assert;
 trait DtoWithoutInvalidFieldTest
 {
     /**
-     * @inheritDoc
+     * @doesNotPerformAssertions
      */
     public function testInvalidField()
     {
         // the test as defined by DtoTest is only relevant to Dto with fields validation
-        Assert::assertTrue(true);
     }
 
     /**

--- a/test/DtoWithoutOptionalFieldsTest.php
+++ b/test/DtoWithoutOptionalFieldsTest.php
@@ -10,12 +10,11 @@ use PHPUnit\Framework\Assert as Assert;
 trait DtoWithoutOptionalFieldsTest
 {
     /**
-     * @inheritDoc
+     * @doesNotPerformAssertions
      */
     public function testDefaultValues()
     {
         // the test as defined by DtoTest is only relevant to Dto with optional fields
-        Assert::assertTrue(true);
     }
 
     /**

--- a/test/Query/Document/AbstractDownloadTest.php
+++ b/test/Query/Document/AbstractDownloadTest.php
@@ -17,7 +17,6 @@ class AbstractDownloadTest extends MockeryTestCase
             'isInline' => 'unit_Inline',
         ];
 
-        /** @var AbstractDownload $class */
         $class = new class extends AbstractDownload {
         };
 

--- a/test/Query/Licence/GoodsVehiclesTest.php
+++ b/test/Query/Licence/GoodsVehiclesTest.php
@@ -14,18 +14,6 @@ use Mockery as m;
 
 class GoodsVehiclesTest extends TestCase
 {
-    public function testGetVehicleIdsIsDefined(): void
-    {
-        // Setup
-        $sut = GoodsVehicles::create([]);
-
-        // Assert
-        $this->assertIsCallable([$sut, 'getVehicleIds']);
-    }
-
-    /**
-     * @depends testGetVehicleIdsIsDefined
-     */
     public function testGetVehicleIdsReturnsAnArrayProvided()
     {
         // Setup
@@ -36,9 +24,6 @@ class GoodsVehiclesTest extends TestCase
         $this->assertEquals($expectedVehicleIds, $sut->getVehicleIds());
     }
 
-    /**
-     * @depends testGetVehicleIdsIsDefined
-     */
     public function testGetVehicleIdsReturnsNullProvided()
     {
         // Setup
@@ -48,9 +33,6 @@ class GoodsVehiclesTest extends TestCase
         $this->assertNull($sut->getVehicleIds());
     }
 
-    /**
-     * @depends testGetVehicleIdsIsDefined
-     */
     public function testGetVehicleIdsReturnsNullWhenNoVehicleIdsProvided()
     {
         // Setup

--- a/vendor-bin/phpcs/composer.json
+++ b/vendor-bin/phpcs/composer.json
@@ -1,6 +1,6 @@
 {
   "require-dev": {
-    "squizlabs/php_codesniffer": "^3.7",
+    "squizlabs/php_codesniffer": "^3.13",
     "dvsa/coding-standards": "^2.0"
   }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
   "require-dev": {
-    "phpstan/phpstan": "^1.10"
+    "phpstan/phpstan": "^2.1"
   }
 }

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,5 +1,5 @@
 {
   "require-dev": {
-    "vimeo/psalm": "^5.15"
+    "vimeo/psalm": "^6.13"
   }
 }


### PR DESCRIPTION
## Description

Related issue: [VOL-6497](https://dvsa.atlassian.net/browse/VOL-6497)

- PHP composer version bumped to ~8.2.0 || ~8.3.0
- minimum versions bumped for Laminas packages
- PhpStan and Psalm both bumped to new major versions
- Static analysis now passing on PHP 8.3
- Code scanning and unit tests have dropped support for PHP 8.0 and 8.1

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6497]: https://dvsa.atlassian.net/browse/VOL-6497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ