### PR TITLE
chore: bump redis platform version to match elasticache, allows laminas package bump VOL-6459

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "laminas/laminas-crypt": "^4",
         "laminas/laminas-xml": "^1.7.0",
         "laminas/laminas-cache": "^3.13",
-        "laminas/laminas-cache-storage-adapter-redis": "^2.7",
+        "laminas/laminas-cache-storage-adapter-redis": "^2.10",
         "laminas/laminas-router": "^3.14",
         "psr/container": "^1.1|^2"
     },
@@ -59,7 +59,7 @@
             "bamarni/composer-bin-plugin": true
         },
         "platform": {
-            "ext-redis": "5.0.2"
+            "ext-redis": "6.2.6"
         }
     }
 }


### PR DESCRIPTION
Related issue: [VOL-6459](https://dvsa.atlassian.net/browse/VOL-6459)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6459]: https://dvsa.atlassian.net/browse/VOL-6459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ