### PR TITLE
chore: vol-5649 - remove legacy Transxchange publisher code

### DIFF
--- a/src/Command/Bus/Ebsr/RequestMap.php
+++ b/src/Command/Bus/Ebsr/RequestMap.php
@@ -17,30 +17,12 @@ class RequestMap extends AbstractCommand
     use Identity;
 
     /**
-     * @var string
      * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"small","large","auto"}})
      */
-    protected $scale;
-
-    /**
-     * @Transfer\Filter("Laminas\Filter\Boolean")
-     * @Transfer\Optional
-     */
-    protected $fromNewEbsr;
-
-    /**
-     * @return string
-     */
-    public function getScale()
+    protected string $scale;
+    
+    public function getScale(): string
     {
         return $this->scale;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getFromNewEbsr()
-    {
-        return $this->fromNewEbsr;
     }
 }

--- a/src/Command/Bus/Ebsr/RequestMap.php
+++ b/src/Command/Bus/Ebsr/RequestMap.php
@@ -20,7 +20,7 @@ class RequestMap extends AbstractCommand
      * @Transfer\Validator("Laminas\Validator\InArray", options={"haystack": {"small","large","auto"}})
      */
     protected string $scale;
-    
+
     public function getScale(): string
     {
         return $this->scale;


### PR DESCRIPTION
## Description

we are now using the new TransXchange Consumer. This allows us to decommission the old code and feature toggle.

Related issue: [VOL-5649](https://dvsa.atlassian.net/browse/VOL-5649)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5649]: https://dvsa.atlassian.net/browse/VOL-5649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ