### PR TITLE
feat: add Template DTOs for notify md migration (VOL-7238)

### DIFF
--- a/config/backend-routes/template/template.php
+++ b/config/backend-routes/template/template.php
@@ -23,6 +23,26 @@ return [
                     'GET' => QueryConfig::getConfig(Query\Template\AvailableTemplates::class),
                 ]
             ],
+            'available-template-groups' => [
+                'type' => 'Segment',
+                'options' => [
+                    'route' => 'available-template-groups[/]',
+                ],
+                'may_terminate' => false,
+                'child_routes' => [
+                    'GET' => QueryConfig::getConfig(Query\Template\AvailableTemplateGroups::class),
+                ]
+            ],
+            'send-test-email' => [
+                'type' => 'Segment',
+                'options' => [
+                    'route' => 'send-test-email[/]',
+                ],
+                'may_terminate' => false,
+                'child_routes' => [
+                    'POST' => CommandConfig::getPostConfig(Command\Template\SendTestEmail::class),
+                ]
+            ],
             'preview-template-source' => [
                 'type' => 'Segment',
                 'options' => [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ parameters:
       paths:
         - 'src/Validators'
         - 'src/Util/ArrayInput.php'
+        - 'src/Router/Query.php'
   - # Laminas have added annotations to say classes we extend will be final in subsequent versions - we can't easily fix this
       identifier: property.parentPropertyFinalByPhpDoc
       paths:

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -19,6 +19,7 @@
           <!-- Laminas have added annotations to some classes we extend, to signify they will be final in upcoming versions -->
           <directory name="src/Validators" />
           <file name="src/Util/ArrayInput.php" />
+          <file name="src/Router/Query.php" />
         </errorLevel>
       </InvalidExtendClass>
       <MethodSignatureMismatch>
@@ -26,6 +27,7 @@
           <!-- Laminas have added annotations to some classes we extend, to signify they will be final in upcoming versions -->
           <directory name="src/Validators" />
           <file name="src/Util/ArrayInput.php" />
+          <file name="src/Router/Query.php" />
         </errorLevel>
       </MethodSignatureMismatch>
     </issueHandlers>

--- a/src/Command/Template/SendTestEmail.php
+++ b/src/Command/Template/SendTestEmail.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Send a one-shot test email for a `format='md'` template via the dedicated NotifyTestMailer.
+ *
+ * Used by the admin CMS at /admin/email-templates so admins can verify the Notify rendering
+ * of a converted template before the env-level mail DSN cutover.
+ */
+
+namespace Dvsa\Olcs\Transfer\Command\Template;
+
+use Dvsa\Olcs\Transfer\Command\AbstractCommand;
+use Dvsa\Olcs\Transfer\FieldType\Traits\Identity;
+use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
+
+/**
+ * @Transfer\RouteName("backend/template/send-test-email")
+ * @Transfer\Method("POST")
+ */
+final class SendTestEmail extends AbstractCommand
+{
+    use Identity;
+
+    /**
+     * @Transfer\Validator("Laminas\Validator\EmailAddress")
+     * @Transfer\Filter("Laminas\Filter\StringTrim")
+     * @var string
+     */
+    protected $recipient;
+
+    public function getRecipient(): string
+    {
+        return (string) $this->recipient;
+    }
+}

--- a/src/Query/Template/AvailableTemplateGroups.php
+++ b/src/Query/Template/AvailableTemplateGroups.php
@@ -1,9 +1,10 @@
 <?php
 
 /**
- * Get templates available for editing
- *
- * @author Jonathan Thomas <jonathan@opalise.co.uk>
+ * Group-by-name view of editable email templates. Returns one row per template `name`,
+ * with the per-variant locale + format coverage as aggregated arrays. Drives the admin
+ * CMS index at /admin/email-templates (VOL-7238 deliverable 7) so the list isn't ~180
+ * (locale × format × name) rows.
  */
 
 namespace Dvsa\Olcs\Transfer\Query\Template;
@@ -17,16 +18,16 @@ use Dvsa\Olcs\Transfer\Query\PagedTrait;
 use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
 
 /**
- * @Transfer\RouteName("backend/template/available-templates")
+ * @Transfer\RouteName("backend/template/available-template-groups")
  */
-class AvailableTemplates extends AbstractQuery implements PagedQueryInterface, OrderedQueryInterface
+class AvailableTemplateGroups extends AbstractQuery implements PagedQueryInterface, OrderedQueryInterface
 {
     use PagedTrait;
     use OrderedTrait;
     use EmailTemplateCategory;
 
     /**
-     * Filter the list by template `format` column. Empty / unset = no filter.
+     * Filter to names that have at least one variant in the given format. Empty = no filter.
      *
      * @Transfer\Optional
      * @var string

--- a/test/Query/Template/AvailableTemplatesTest.php
+++ b/test/Query/Template/AvailableTemplatesTest.php
@@ -18,7 +18,8 @@ class AvailableTemplatesTest extends TestCase
             'sort' => null,
             'order' => null,
             'sortWhitelist' => [],
-            'emailTemplateCategory' => null
+            'emailTemplateCategory' => null,
+            'format' => ''
         ];
         $sut = AvailableTemplates::create($data);
 


### PR DESCRIPTION
## Description

- AvailableTemplates: new optional `format` filter property
- AvailableTemplateGroups: new query DTO for the group-by-name index
- SendTestEmail: new command DTO for the admin "Send test" action
- route registrations in backend-routes/template/template.php

Related issue: VOL-7238

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
