### PR TITLE
feat: add letterTodos field to LetterIssue Create/Update DTOs (VOL-7280)

### DIFF
--- a/src/Command/Letter/LetterIssue/Create.php
+++ b/src/Command/Letter/LetterIssue/Create.php
@@ -99,6 +99,23 @@ final class Create extends AbstractCommand
     protected $letterIssueTypeId;
 
     /**
+     * IDs of LetterTodos to link to this issue's current version (VOL-7280).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\ArrayInput
+     */
+    protected $letterTodos;
+
+    /**
+     * @return array
+     */
+    public function getLetterTodos()
+    {
+        return $this->letterTodos;
+    }
+
+    /**
      * @return string
      */
     public function getIssueKey()

--- a/src/Command/Letter/LetterIssue/Update.php
+++ b/src/Command/Letter/LetterIssue/Update.php
@@ -101,6 +101,23 @@ final class Update extends AbstractCommand
     protected $letterIssueTypeId;
 
     /**
+     * IDs of LetterTodos to link to this issue's current version (VOL-7280).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\ArrayInput
+     */
+    protected $letterTodos;
+
+    /**
+     * @return array
+     */
+    public function getLetterTodos()
+    {
+        return $this->letterTodos;
+    }
+
+    /**
      * @return string
      */
     public function getIssueKey()


### PR DESCRIPTION
Unblocks vol-app PR #1515 (already merged) — the merged batch 2 application code in vol-app/main calls `$command->getLetterTodos()` on a DTO that doesn't currently expose it. Adds the optional `letterTodos` array field to both `LetterIssue\Create` and `LetterIssue\Update` so the deployed app stops being one user action away from a fatal.