### PR TITLE
feat: add chrome slot fields to MasterTemplate Create/Update DTOs (VOL-7305)

### DIFF
--- a/src/Command/Letter/MasterTemplate/Create.php
+++ b/src/Command/Letter/MasterTemplate/Create.php
@@ -112,7 +112,7 @@ final class Create extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getHeaderLeftContent()
     {
@@ -120,7 +120,7 @@ final class Create extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getHeaderRightContent()
     {
@@ -128,7 +128,7 @@ final class Create extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getSignoffContent()
     {
@@ -136,7 +136,7 @@ final class Create extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getFooterContent()
     {

--- a/src/Command/Letter/MasterTemplate/Create.php
+++ b/src/Command/Letter/MasterTemplate/Create.php
@@ -32,12 +32,51 @@ final class Create extends AbstractCommand
     protected $isDefault = false;
 
     /**
+     * Locale / chrome variant key. Extended vocabulary supports values beyond strict
+     * ISO codes, e.g. en_GB, en_NI, cy_GB, customN_GB (VOL-7305).
+     *
      * @var string
      * @Transfer\Optional
      * @Transfer\Filter("Laminas\Filter\StringTrim")
-     * @Transfer\Validator("Laminas\Validator\StringLength", options={"max":5})
+     * @Transfer\Validator("Laminas\Validator\StringLength", options={"max":20})
      */
     protected $locale;
+
+    /**
+     * EditorJS JSON for the top-left header slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $headerLeftContent;
+
+    /**
+     * EditorJS JSON for the top-right header slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $headerRightContent;
+
+    /**
+     * EditorJS JSON for the signoff slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $signoffContent;
+
+    /**
+     * EditorJS JSON for the footer slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $footerContent;
 
 
     /**
@@ -70,5 +109,37 @@ final class Create extends AbstractCommand
     public function getLocale()
     {
         return $this->locale;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getHeaderLeftContent()
+    {
+        return $this->headerLeftContent;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getHeaderRightContent()
+    {
+        return $this->headerRightContent;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getSignoffContent()
+    {
+        return $this->signoffContent;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getFooterContent()
+    {
+        return $this->footerContent;
     }
 }

--- a/src/Command/Letter/MasterTemplate/Update.php
+++ b/src/Command/Letter/MasterTemplate/Update.php
@@ -36,12 +36,51 @@ final class Update extends AbstractCommand
     protected $isDefault;
 
     /**
+     * Locale / chrome variant key. Extended vocabulary supports values beyond strict
+     * ISO codes, e.g. en_GB, en_NI, cy_GB, customN_GB (VOL-7305).
+     *
      * @var string
      * @Transfer\Optional
      * @Transfer\Filter("Laminas\Filter\StringTrim")
-     * @Transfer\Validator("Laminas\Validator\StringLength", options={"max":5})
+     * @Transfer\Validator("Laminas\Validator\StringLength", options={"max":20})
      */
     protected $locale;
+
+    /**
+     * EditorJS JSON for the top-left header slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $headerLeftContent;
+
+    /**
+     * EditorJS JSON for the top-right header slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $headerRightContent;
+
+    /**
+     * EditorJS JSON for the signoff slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $signoffContent;
+
+    /**
+     * EditorJS JSON for the footer slot (VOL-7305).
+     *
+     * @var array
+     * @Transfer\Optional
+     * @Transfer\Escape(false)
+     */
+    protected $footerContent;
 
 
     /**
@@ -74,5 +113,37 @@ final class Update extends AbstractCommand
     public function getLocale()
     {
         return $this->locale;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getHeaderLeftContent()
+    {
+        return $this->headerLeftContent;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getHeaderRightContent()
+    {
+        return $this->headerRightContent;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getSignoffContent()
+    {
+        return $this->signoffContent;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getFooterContent()
+    {
+        return $this->footerContent;
     }
 }

--- a/src/Command/Letter/MasterTemplate/Update.php
+++ b/src/Command/Letter/MasterTemplate/Update.php
@@ -116,7 +116,7 @@ final class Update extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getHeaderLeftContent()
     {
@@ -124,7 +124,7 @@ final class Update extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getHeaderRightContent()
     {
@@ -132,7 +132,7 @@ final class Update extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getSignoffContent()
     {
@@ -140,7 +140,7 @@ final class Update extends AbstractCommand
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getFooterContent()
     {


### PR DESCRIPTION
Required by the in-flight vol-app letters chrome batch (VOL-7305) which moves the agency address, signoff and footer out of hardcoded PHP into admin-editable EditorJS fields on MasterTemplate. Adds four optional array fields — `headerLeftContent`, `headerRightContent`, `signoffContent`, `footerContent` — and widens `locale` to 20 chars to support en_NI and future custom-chrome variants.