### PR TITLE
fix: vol 5983 fee from unrelated record bug

### DIFF
--- a/src/Command/ContinuationDetail/Queue.php
+++ b/src/Command/ContinuationDetail/Queue.php
@@ -30,7 +30,6 @@ final class Queue extends AbstractCommand
      * @Transfer\Validator("Laminas\Validator\InArray",
      *      options={
      *          "haystack": {
-     *              "que_typ_cont_check_rem_gen_let",
      *              "que_typ_cpid_export_csv",
      *              "que_typ_ch_initial",
      *              "que_typ_ch_compare",

--- a/src/Query/Fee/Fee.php
+++ b/src/Query/Fee/Fee.php
@@ -14,4 +14,24 @@ use Dvsa\Olcs\Transfer\FieldType\Traits as FieldTypeTraits;
 class Fee extends AbstractQuery implements FieldType\IdentityInterface
 {
     use FieldTypeTraits\Identity;
+
+    /**
+     * @Transfer\Optional
+     */
+    protected ?int $licenceId = null;
+
+    /**
+     * @Transfer\Optional
+     */
+    protected ?int $applicationId = null;
+
+    public function getLicenceId(): ?int
+    {
+        return $this->licenceId;
+    }
+
+    public function getApplicationId(): ?int
+    {
+        return $this->applicationId;
+    }
 }


### PR DESCRIPTION
## Description

Adds optional licenceId and applicationId fields to the Fee query DTO, allowing callers to scope a fee lookup to a specific licence or application context. Both default to null and are marked @Transfer\Optional, so existing callers are unaffected.

Related issue: [VOL-5983](https://dvsa.atlassian.net/browse/VOL-5983)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5983]: https://dvsa.atlassian.net/browse/VOL-5983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ