### PR TITLE
fix: vol 5981 view unrelated penalty from other cases bug

### DIFF
--- a/src/Query/Cases/Si/Si.php
+++ b/src/Query/Cases/Si/Si.php
@@ -19,4 +19,14 @@ use Dvsa\Olcs\Transfer\Query\AbstractQuery;
 class Si extends AbstractQuery implements CacheableShortTermQueryInterface
 {
     use Identity;
+
+    /**
+     * @Transfer\Optional
+     */
+    protected ?int $caseId = null;
+
+    public function getCaseId(): ?int
+    {
+        return $this->caseId;
+    }
 }


### PR DESCRIPTION
## Description

Bug where user can view penalty serious infringement from a different case. Now added an optional parameter to DTO and function so controller can optionally fulfil these variables and can check the parent of a serious infringement to see if it belongs to a case.

Related issue: [VOL-5981](https://dvsa.atlassian.net/browse/VOL-5981)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5981]: https://dvsa.atlassian.net/browse/VOL-5981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ